### PR TITLE
MSIX app version could not be opened

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -592,11 +592,21 @@ packages:
   msix:
     dependency: "direct dev"
     description:
-      name: msix
-      sha256: "519b183d15dc9f9c594f247e2d2339d855cf0eaacc30e19b128e14f3ecc62047"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: msvc_redist
+      resolved-ref: "4c5cd4c3187bbe2eb8365f11c3d929e4d1aeac92"
+      url: "https://github.com/insertjokehere/msix.git"
+    source: git
     version: "3.16.7"
+  msvcredist:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: main
+      resolved-ref: d46cb7bed55038d4648e28b04f5432e843bd1a24
+      url: "https://github.com/insertjokehere/flutter_msvcredist.git"
+    source: git
+    version: "0.1.0"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,14 +28,24 @@ dependencies:
     url_launcher: ^6.3.0
     package_info_plus: ^8.0.0
 
+    msvcredist:
+        git:
+            url: https://github.com/insertjokehere/flutter_msvcredist.git
+            ref: main
+
 dev_dependencies:
     flutter_test:
         sdk: flutter
 
     flutter_lints: ^4.0.0
     flutter_launcher_icons: "^0.13.1"
-    msix: ^3.16.7
+    # msix: ^3.16.7
     build_runner: ^2.4.7
+
+    msix:
+        git:
+            url: https://github.com/insertjokehere/msix.git
+            ref: msvc_redist
 
 flutter_launcher_icons:
     image_path: "assets/img/Logo-1024.png"
@@ -51,7 +61,6 @@ msix_config:
     publisher_display_name: Artem Bagin
     publisher: CN=DDE4AEE6-9493-4839-AD4F-C696473218F4
     identity_name: 63552ArtemBagin.Spheroscopic
-    store: true
 
     languages: en-us
     logo_path: "assets/img/Logo-1024.png"

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_acrylic/flutter_acrylic_plugin.h>
+#include <msvcredist/msvcredist_plugin_c_api.h>
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
 #include <system_theme/system_theme_plugin.h>
@@ -22,6 +23,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterAcrylicPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterAcrylicPlugin"));
+  MsvcredistPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("MsvcredistPluginCApi"));
   ScreenRetrieverPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverPlugin"));
   SentryFlutterPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   desktop_drop
   file_selector_windows
   flutter_acrylic
+  msvcredist
   screen_retriever
   sentry_flutter
   system_theme


### PR DESCRIPTION
[https://github.com/YehudaKremer/msix/issues/272](https://github.com/YehudaKremer/msix/issues/272)

As I understood the MSIX package uses ancient version of the VC++ runtime, and bundles them into the generated installer. That's the reason why app doesn't launch. I will temporary use the suggested fix.

The error occurs after trying to open Spheroscopic:
```
Faulting application name: Spheroscopic.exe, version: 1.2.2.0, time stamp: 0x66a9f1bf
Faulting module name: MSVCP140.dll, version: 14.27.29112.0, time stamp: 0x5f61068a
Exception code: 0xc0000005
Fault offset: 0x0000000000012af0
Faulting process id: 0x0x2140
Faulting application start time: 0x0x1DAE3216B16FEC2
Faulting application path: C:\Program Files\WindowsApps\63552ArtemBagin.Spheroscopic_1.2.2.0_x64__fxkeb4dgdm144\Spheroscopic.exe
Faulting module path: C:\Program Files\WindowsApps\63552ArtemBagin.Spheroscopic_1.2.2.0_x64__fxkeb4dgdm144\MSVCP140.dll
Report Id: b19be9c6-b10a-4cb7-81c2-ae3ca692f848
Faulting package full name: 63552ArtemBagin.Spheroscopic_1.2.2.0_x64__fxkeb4dgdm144
Faulting package-relative application ID: Spheroscopic
```